### PR TITLE
Shared Pointers Anonymous

### DIFF
--- a/source/TouhouDanmakufu/Common/StgEnemy.cpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.cpp
@@ -171,13 +171,13 @@ bool StgEnemyBossSceneObject::_NextStep() {
 		objectManager->ActivateObject(obj->GetObjectID(), true);
 	}
 
-	shared_ptr<ManagedScript> script = activeData_->GetScriptPointer();
-	if (!script->IsLoad()) {
+	weak_ptr<ManagedScript> pWeakScript = activeData_->GetScriptPointer();
+	shared_ptr<ManagedScript> pScript = pWeakScript.lock();
+	if (!pScript->IsLoad()) {
 		throw gstd::wexception(StringUtility::Format(L"_NextStep: Script wasn't loaded or has been unloaded. [%d, %d]",
 			dataStep_, dataIndex_));
-	}
-	else {
-		scriptManager->StartScript(script);
+	} else {
+		scriptManager->StartScript(pScript);
 	}
 
 	scriptManager->RequestEventAll(StgStageScript::EV_START_BOSS_STEP);
@@ -272,7 +272,8 @@ void StgEnemyBossSceneObject::Activate() {
 	for (std::vector<ref_unsync_ptr<StgEnemyBossSceneData>>& iStep : listData_) {
 		size_t iData = 0;
 		for (ref_unsync_ptr<StgEnemyBossSceneData>& pData : iStep) {
-			shared_ptr<ManagedScript> script = pData->GetScriptPointer();
+			weak_ptr<ManagedScript> weakScript = pData->GetScriptPointer();
+			shared_ptr<ManagedScript> script = weakScript.lock();
 
 			if (script == nullptr)
 				throw gstd::wexception(StringUtility::Format(L"Script wasn't loaded: %s", pData->GetPath().c_str()));

--- a/source/TouhouDanmakufu/Common/StgEnemy.hpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.hpp
@@ -133,7 +133,7 @@ public:
 class StgEnemyBossSceneData {
 private:
 	std::wstring path_;
-	shared_ptr<ManagedScript> ptrScript_;
+	weak_ptr<ManagedScript> ptrScript_;
 
 	std::vector<double> listLife_;
 	std::vector<ref_unsync_ptr<StgEnemyBossObject>> listEnemyObject_;
@@ -157,8 +157,8 @@ public:
 
 	std::wstring& GetPath() { return path_; }
 	void SetPath(const std::wstring& path) { path_ = path; }
-	shared_ptr<ManagedScript> GetScriptPointer() { return ptrScript_; }
-	void SetScriptPointer(shared_ptr<ManagedScript> id) { ptrScript_ = id; }
+	weak_ptr<ManagedScript> GetScriptPointer() { return ptrScript_; }
+	void SetScriptPointer(weak_ptr<ManagedScript> id) { ptrScript_ = id; }
 
 	std::vector<double>& GetLifeList() { return listLife_; }
 	void SetLifeList(std::vector<double>& list) { listLife_ = list; }


### PR DESCRIPTION
Fixes #20.

My initial theory was that the unloading texture bug was the reason why it happened, but as it turns out, it was just a side effect of the actual bug. The exclusive usage of shared pointers, for whatever reason, caused scripts and their texture references to not automatically be closed upon termination.

This reverts the shared_ptr edits found in [this commit](https://github.com/Natashi/Touhou-Danmakufu-ph3sx-2/commit/3bc42286799b3eeb6a0d7ec0a53362bd9e394267), which is the exact timepoint when the texture bug started to occur.
Later down the line, when the swap to fstream for handling files from the Win32 API and its CloseFile(HANDLE) syntax was made, file objects everywhere simply weren't closed properly, resulting in too many files being open. I'm unsure why this in particular would cause the crash, though...

tl;dr weak_ptr.lock() != shared_ptr in terms of garbage collection/etc. and fstream doesn't like that thus eternal sadness