### PR TITLE
The missing link: ColorHexRGBtoHSV

### DIFF
--- a/source/GcLib/directx/DxScript.cpp
+++ b/source/GcLib/directx/DxScript.cpp
@@ -223,6 +223,7 @@ static const std::vector<function> dxFunction = {
 	{ "ColorHexToARGB", DxScript::Func_ColorHexToARGB, 1 },
 	{ "ColorHexToARGB", DxScript::Func_ColorHexToARGB, 2 },		//Overloaded
 	{ "ColorRGBtoHSV", DxScript::Func_ColorRGBtoHSV, 3 },
+	{ "ColorHexRGBtoHSV", DxScript::Func_ColorHexRGBtoHSV, 1 },
 	{ "ColorHSVtoRGB", DxScript::Func_ColorHSVtoRGB, 3 },
 	{ "ColorHSVtoHexRGB", DxScript::Func_ColorHSVtoHexRGB, 3 },
 
@@ -2299,6 +2300,17 @@ gstd::value DxScript::Func_ColorRGBtoHSV(gstd::script_machine* machine, int argc
 	byte cr = argv[0].as_int();
 	byte cg = argv[1].as_int();
 	byte cb = argv[2].as_int();
+
+	D3DXVECTOR3 hsv;
+	ColorAccess::RGBtoHSV(hsv, cr, cg, cb);
+
+	return DxScript::CreateIntArrayValue(reinterpret_cast<FLOAT*>(&hsv), 3U);
+}
+gstd::value DxScript::Func_ColorHexRGBtoHSV(gstd::script_machine* machine, int argc, const gstd::value* argv) {
+	D3DCOLOR rgb = (D3DCOLOR)argv[0].as_int();
+	byte cr = ColorAccess::GetColorR(rgb);
+	byte cg = ColorAccess::GetColorG(rgb);
+	byte cb = ColorAccess::GetColorB(rgb);
 
 	D3DXVECTOR3 hsv;
 	ColorAccess::RGBtoHSV(hsv, cr, cg, cb);

--- a/source/GcLib/directx/DxScript.hpp
+++ b/source/GcLib/directx/DxScript.hpp
@@ -233,6 +233,7 @@ namespace directx {
 		DNH_FUNCAPI_DECL_(Func_ColorARGBToHex);
 		DNH_FUNCAPI_DECL_(Func_ColorHexToARGB);
 		DNH_FUNCAPI_DECL_(Func_ColorRGBtoHSV);
+		DNH_FUNCAPI_DECL_(Func_ColorHexRGBtoHSV);
 		DNH_FUNCAPI_DECL_(Func_ColorHSVtoRGB);
 		DNH_FUNCAPI_DECL_(Func_ColorHSVtoHexRGB);
 


### PR DESCRIPTION
This shouldn't be necessary.
![image](https://user-images.githubusercontent.com/31663251/130711250-10ee147f-ef69-47b7-b83a-cc9b6f4929cc.png)
