### PR TITLE
Fix 0,0 spawning with CreateItemU1/2, apparently

### DIFF
--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -2009,8 +2009,8 @@ gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int
 		int64_t score = argv[3].as_int();
 		D3DXVECTOR2 to = D3DXVECTOR2(posX, posY - 128);
 
-		obj->SetPositionX(posX);
-		obj->SetPositionY(posY);
+		obj->SetX(posX);
+		obj->SetY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 	}
@@ -2036,8 +2036,8 @@ gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int
 		D3DXVECTOR2 to = D3DXVECTOR2(argv[3].as_real(), argv[4].as_real());
 		int64_t score = argv[5].as_int();
 
-		obj->SetPositionX(posX);
-		obj->SetPositionY(posY);
+		obj->SetX(posX);
+		obj->SetY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 	}
@@ -2064,12 +2064,12 @@ gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int
 		int64_t score = argv[3].as_int();
 		D3DXVECTOR2 to = D3DXVECTOR2(posX, posY - 128);
 
-		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
-		obj->SetPositionX(posX);
-		obj->SetPositionY(posY);
+		obj->SetX(posX);
+		obj->SetY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 		obj->SetImageID(itemID);
+		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	}
 	return script->CreateIntValue(id);
 }
@@ -2094,12 +2094,12 @@ gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int
 		D3DXVECTOR2 to = D3DXVECTOR2(argv[3].as_real(), argv[4].as_real());
 		int64_t score = argv[5].as_int();
 
-		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
-		obj->SetPositionX(posX);
-		obj->SetPositionY(posY);
+		obj->SetX(posX);
+		obj->SetY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 		obj->SetImageID(itemID);
+		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	}
 	return script->CreateIntValue(id);
 }

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -2064,12 +2064,12 @@ gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int
 		int64_t score = argv[3].as_int();
 		D3DXVECTOR2 to = D3DXVECTOR2(posX, posY - 128);
 
+		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 		obj->SetPositionX(posX);
 		obj->SetPositionY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 		obj->SetImageID(itemID);
-		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	}
 	return script->CreateIntValue(id);
 }
@@ -2094,12 +2094,12 @@ gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int
 		D3DXVECTOR2 to = D3DXVECTOR2(argv[3].as_real(), argv[4].as_real());
 		int64_t score = argv[5].as_int();
 
+		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 		obj->SetPositionX(posX);
 		obj->SetPositionY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 		obj->SetImageID(itemID);
-		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	}
 	return script->CreateIntValue(id);
 }


### PR DESCRIPTION
Apparently, calling SetMoveType first instead of last makes items no longer flicker to 0,0 for a single frame.

Amazing.