### PR TITLE
Unfuck text objects

### DIFF
--- a/source/GcLib/directx/DxScript.cpp
+++ b/source/GcLib/directx/DxScript.cpp
@@ -425,6 +425,7 @@ static const std::vector<function> dxFunction = {
 	{ "ObjText_SetTransCenter", DxScript::Func_ObjText_SetTransCenter, 3 },
 	{ "ObjText_SetAutoTransCenter", DxScript::Func_ObjText_SetAutoTransCenter, 2 },
 	{ "ObjText_SetHorizontalAlignment", DxScript::Func_ObjText_SetHorizontalAlignment, 2 },
+	{ "ObjText_SetVerticalAlignment", DxScript::Func_ObjText_SetVerticalAlignment, 2 },
 	{ "ObjText_SetSyntacticAnalysis", DxScript::Func_ObjText_SetSyntacticAnalysis, 2 },
 	{ "ObjText_GetText", DxScript::Func_ObjText_GetText, 1 },
 	{ "ObjText_GetTextLength", DxScript::Func_ObjText_GetTextLength, 1 },
@@ -4313,6 +4314,16 @@ gstd::value DxScript::Func_ObjText_SetHorizontalAlignment(gstd::script_machine* 
 	if (obj) {
 		TextAlignment align = (TextAlignment)argv[1].as_int();
 		obj->SetHorizontalAlignment(align);
+	}
+	return value();
+}
+gstd::value DxScript::Func_ObjText_SetVerticalAlignment(gstd::script_machine* machine, int argc, const gstd::value* argv) {
+	DxScript* script = (DxScript*)machine->data;
+	int id = argv[0].as_int();
+	DxScriptTextObject* obj = script->GetObjectPointerAs<DxScriptTextObject>(id);
+	if (obj) {
+		TextAlignment align = (TextAlignment)argv[1].as_int();
+		obj->SetVerticalAlignment(align);
 	}
 	return value();
 }

--- a/source/GcLib/directx/DxScript.hpp
+++ b/source/GcLib/directx/DxScript.hpp
@@ -416,6 +416,7 @@ namespace directx {
 		static gstd::value Func_ObjText_SetTransCenter(gstd::script_machine* machine, int argc, const gstd::value* argv);
 		static gstd::value Func_ObjText_SetAutoTransCenter(gstd::script_machine* machine, int argc, const gstd::value* argv);
 		static gstd::value Func_ObjText_SetHorizontalAlignment(gstd::script_machine* machine, int argc, const gstd::value* argv);
+		static gstd::value Func_ObjText_SetVerticalAlignment(gstd::script_machine* machine, int argc, const gstd::value* argv);
 		static gstd::value Func_ObjText_SetSyntacticAnalysis(gstd::script_machine* machine, int argc, const gstd::value* argv);
 		static gstd::value Func_ObjText_GetText(gstd::script_machine* machine, int argc, const gstd::value* argv);
 		static gstd::value Func_ObjText_GetTextLength(gstd::script_machine* machine, int argc, const gstd::value* argv);

--- a/source/GcLib/directx/DxText.cpp
+++ b/source/GcLib/directx/DxText.cpp
@@ -188,7 +188,7 @@ bool DxCharGlyph::Create(UINT code, const Font& winFont, const DxFont* dxFont) {
 							else destAlpha = 0;
 
 							//color = ColorAccess::SetColorA(color, ColorAccess::GetColorA(colorBorder)*count/255);
-							byte c_a = ColorAccess::ClampColorRet(colorBorder[0] * destAlpha / 255);
+							byte c_a = (byte)ColorAccess::ClampColorRet(colorBorder[0] * destAlpha / 255);
 							color = D3DCOLOR_ARGB(c_a, colorBorder[1], colorBorder[2], colorBorder[3]);
 						}
 						else {				//Generate internal borders + smooth outlines
@@ -747,7 +747,7 @@ shared_ptr<DxTextLine> DxTextRenderer::_GetTextInfoSub(const std::wstring& text,
 	LONG widthBorder = dxFont.GetBorderType() != TextBorderType::None ? dxFont.GetBorderWidth() : 0L;
 	textLine->SetSidePitch(sidePitch);
 
-	if (widthMax < dxText->GetFontSize())
+	if (widthMax > 0 && widthMax < dxText->GetFontSize())
 		return nullptr;
 
 	const std::wstring strFirstForbid = L"」、。";
@@ -780,11 +780,11 @@ shared_ptr<DxTextLine> DxTextRenderer::_GetTextInfoSub(const std::wstring& text,
 		SIZE size = _GetTextSize(hDC, pText);
 		LONG lw = size.cx + widthBorder + sidePitch;
 		LONG lh = size.cy;
-		if (totalHeight + size.cy > heightMax) {
+		if (heightMax > 0 && totalHeight + size.cy > heightMax) {
 			textLine = nullptr;
 			break;
 		}
-		if (textLine->width_ + lw + sizeNext.cx >= widthMax) {
+		if (widthMax > 0 && textLine->width_ + lw + sizeNext.cx >= widthMax) {
 			//改行
 			totalWidth = std::max(totalWidth, textLine->width_);
 			totalHeight += textLine->height_ + linePitch;
@@ -1425,7 +1425,7 @@ shared_ptr<DxTextRenderObject> DxTextRenderer::CreateRenderObject(DxText* dxText
 				}
 
 				heightTotal += textLine->height_ + linePitch;
-				if (heightTotal > heightMax) break;
+				if (heightMax > 0 && heightTotal > heightMax) break;
 
 				_CreateRenderObject(objRender, dxText, pos, dxFont, textLine);
 
@@ -1494,8 +1494,8 @@ DxText::DxText() {
 
 	pos_.x = 0;
 	pos_.y = 0;
-	widthMax_ = INT_MAX;
-	heightMax_ = INT_MAX;
+	widthMax_ = 0;
+	heightMax_ = 0;
 	sidePitch_ = 0;
 	linePitch_ = 4;
 	fixedWidth_ = 0;


### PR DESCRIPTION
Added ObjText_SetVerticalAlignment because it has no reason not to exist.

Also made it so that text objects are properly centered around their positional coordinates with greater-than-zero max widths/heights.