### PR TITLE
Shot Penetration DLC+α

### DIFF
--- a/source/GcLib/gstd/ScriptClient.cpp
+++ b/source/GcLib/gstd/ScriptClient.cpp
@@ -124,11 +124,11 @@ static const std::vector<function> commonFunction = {
 	{ "reset_count_prand", ScriptClientBase::Func_ResetRandEffCount, 0 },
 
 	//Interpolation
-	{ "Interpolate_Linear", ScriptClientBase::Func_Interpolate_Linear, 3 },
-	{ "Interpolate_Smooth", ScriptClientBase::Func_Interpolate_Smooth, 3 },
-	{ "Interpolate_Smoother", ScriptClientBase::Func_Interpolate_Smoother, 3 },
-	{ "Interpolate_Accelerate", ScriptClientBase::Func_Interpolate_Accelerate, 3 },
-	{ "Interpolate_Decelerate", ScriptClientBase::Func_Interpolate_Decelerate, 3 },
+	{ "Interpolate_Linear", ScriptClientBase::Func_Interpolate<Math::Lerp::Linear>, 3 },
+	{ "Interpolate_Smooth", ScriptClientBase::Func_Interpolate<Math::Lerp::Smooth>, 3 },
+	{ "Interpolate_Smoother", ScriptClientBase::Func_Interpolate<Math::Lerp::Smoother>, 3 },
+	{ "Interpolate_Accelerate", ScriptClientBase::Func_Interpolate<Math::Lerp::Accelerate>, 3 },
+	{ "Interpolate_Decelerate", ScriptClientBase::Func_Interpolate<Math::Lerp::Decelerate>, 3 },
 	{ "Interpolate_Modulate", ScriptClientBase::Func_Interpolate_Modulate, 4 },
 	{ "Interpolate_Overshoot", ScriptClientBase::Func_Interpolate_Overshoot, 4 },
 	{ "Interpolate_QuadraticBezier", ScriptClientBase::Func_Interpolate_QuadraticBezier, 4 },
@@ -863,25 +863,10 @@ static value _ScriptValueLerp(script_machine* machine, const value* v1, const va
 		return ScriptClientBase::CreateRealValue(lerpFunc(v1->as_real(), v2->as_real(), vx));
 	}
 }
-value ScriptClientBase::Func_Interpolate_Linear(script_machine* machine, int argc, const value* argv) {
+template<double (*func)(double, double, double)>
+value ScriptClientBase::Func_Interpolate(script_machine* machine, int argc, const value* argv) {
 	double x = argv[2].as_real();
-	return _ScriptValueLerp(machine, &argv[0], &argv[1], x, Math::Lerp::Linear);
-}
-value ScriptClientBase::Func_Interpolate_Smooth(script_machine* machine, int argc, const value* argv) {
-	double x = argv[2].as_real();
-	return _ScriptValueLerp(machine, &argv[0], &argv[1], x, Math::Lerp::Smooth);
-}
-value ScriptClientBase::Func_Interpolate_Smoother(script_machine* machine, int argc, const value* argv) {
-	double x = argv[2].as_real();
-	return _ScriptValueLerp(machine, &argv[0], &argv[1], x, Math::Lerp::Smoother);
-}
-value ScriptClientBase::Func_Interpolate_Accelerate(script_machine* machine, int argc, const value* argv) {
-	double x = argv[2].as_real();
-	return _ScriptValueLerp(machine, &argv[0], &argv[1], x, Math::Lerp::Accelerate);
-}
-value ScriptClientBase::Func_Interpolate_Decelerate(script_machine* machine, int argc, const value* argv) {
-	double x = argv[2].as_real();
-	return _ScriptValueLerp(machine, &argv[0], &argv[1], x, Math::Lerp::Decelerate);
+	return _ScriptValueLerp(machine, &argv[0], &argv[1], x, func);
 }
 value ScriptClientBase::Func_Interpolate_Modulate(script_machine* machine, int argc, const value* argv) {
 	double a = argv[0].as_real();

--- a/source/GcLib/gstd/ScriptClient.hpp
+++ b/source/GcLib/gstd/ScriptClient.hpp
@@ -249,11 +249,8 @@ namespace gstd {
 		DNH_FUNCAPI_DECL_(Func_ReflectAngleR);
 
 		//Math functions; interpolation
-		DNH_FUNCAPI_DECL_(Func_Interpolate_Linear);
-		DNH_FUNCAPI_DECL_(Func_Interpolate_Smooth);
-		DNH_FUNCAPI_DECL_(Func_Interpolate_Smoother);
-		DNH_FUNCAPI_DECL_(Func_Interpolate_Accelerate);
-		DNH_FUNCAPI_DECL_(Func_Interpolate_Decelerate);
+		template<double (*func)(double, double, double)>
+		DNH_FUNCAPI_DECL_(Func_Interpolate);
 		DNH_FUNCAPI_DECL_(Func_Interpolate_Modulate);
 		DNH_FUNCAPI_DECL_(Func_Interpolate_Overshoot);
 		DNH_FUNCAPI_DECL_(Func_Interpolate_QuadraticBezier);

--- a/source/TouhouDanmakufu/Common/StgEnemy.cpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.cpp
@@ -180,8 +180,24 @@ void StgEnemyObject::Intersect(StgIntersectionTarget* ownTarget, StgIntersection
 	if (auto ptrObj = otherTarget->GetObject()) {
 		if (otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SHOT) {
 			if (StgShotObject* shot = dynamic_cast<StgShotObject*>(ptrObj.get())) {
-				damage = shot->GetDamage() * (shot->IsSpellFactor() ? rateDamageSpell_ : rateDamageShot_) / 100.0;
-				++intersectedPlayerShotCount_;
+				ref_unsync_weak_ptr<StgEnemyObject> self = ownTarget->GetObject();
+				auto& list = shot->GetEnemyIntersectionInvalidFramePairList();
+				bool bHit = list.size() == 0 || std::find_if(list.begin(), list.end(),
+					[&self](const std::pair<ref_unsync_weak_ptr<StgEnemyObject>, int>& element) { return element.first == self; }) == list.end();
+
+				if (bHit) {
+					damage = shot->GetDamage() * (shot->IsSpellFactor() ? rateDamageSpell_ : rateDamageShot_) / 100.0;
+					++intersectedPlayerShotCount_;
+
+					int frame = shot->GetEnemyIntersectionInvalidFrame();
+
+					if (frame > 0) {
+						auto pair = std::make_pair(self, frame);
+						auto& list = shot->GetEnemyIntersectionInvalidFramePairList();
+						list.push_back(pair);
+					}
+				}
+				
 			}
 		}
 		else if (otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SPELL) {

--- a/source/TouhouDanmakufu/Common/StgShot.cpp
+++ b/source/TouhouDanmakufu/Common/StgShot.cpp
@@ -987,10 +987,25 @@ void StgShotObject::Intersect(StgIntersectionTarget* ownTarget, StgIntersectionT
 		break;
 	}
 	case StgIntersectionTarget::TYPE_ENEMY:
+	{
+		//Don't reduce penetration with lasers
+		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr) {
+			bool bHit = listHitEnemy_.size() == 0 || std::find_if(listHitEnemy_.begin(), listHitEnemy_.end(),
+				[&obj](const std::pair<ref_unsync_weak_ptr<StgEnemyObject>, int>& element) { return element.first == obj; }) == listHitEnemy_.end();
+
+			if (bHit) {
+				--life_;
+				if (life_ == 0) {
+					_RequestPlayerDeleteEvent(obj.IsExists() ? obj->GetDxScriptObjectID() : DxScript::ID_INVALID);
+				}
+			}
+		}
+		break;
+	}
 	case StgIntersectionTarget::TYPE_ENEMY_SHOT:
 	{
 		//Don't reduce penetration with lasers
-		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr && (otherType == StgIntersectionTarget::TYPE_ENEMY || bPenetrateShot_)) {
+		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr && bPenetrateShot_) {
 			--life_;
 			if (life_ == 0) {
 				_RequestPlayerDeleteEvent(obj.IsExists() ? obj->GetDxScriptObjectID() : DxScript::ID_INVALID);

--- a/source/TouhouDanmakufu/Common/StgShot.cpp
+++ b/source/TouhouDanmakufu/Common/StgShot.cpp
@@ -913,7 +913,7 @@ void StgShotObject::_CommonWorkTask() {
 		auto& itr = listHitEnemy_.begin();
 		while (itr != listHitEnemy_.end()) {
 			--itr->second;
-			if (itr->second <= 0)
+			if (itr->second == 0)
 				itr = listHitEnemy_.erase(itr);
 			else
 				++itr;
@@ -988,32 +988,23 @@ void StgShotObject::Intersect(StgIntersectionTarget* ownTarget, StgIntersectionT
 	}
 	case StgIntersectionTarget::TYPE_ENEMY:
 	{
-		//Don't reduce penetration with lasers
-		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr) {
+		if (!bSpellResist_) {
 			bool bHit = listHitEnemy_.size() == 0 || std::find_if(listHitEnemy_.begin(), listHitEnemy_.end(),
 				[&obj](const std::pair<ref_unsync_weak_ptr<StgEnemyObject>, int>& element) { return element.first == obj; }) == listHitEnemy_.end();
 
-			if (bHit) {
-				--life_;
-				if (life_ == 0) {
-					_RequestPlayerDeleteEvent(obj.IsExists() ? obj->GetDxScriptObjectID() : DxScript::ID_INVALID);
-				}
-			}
+			if (bHit) --life_;
 		}
 		break;
 	}
 	case StgIntersectionTarget::TYPE_ENEMY_SHOT:
 	{
-		//Don't reduce penetration with lasers
-		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr && bPenetrateShot_) {
-			--life_;
-			if (life_ == 0) {
-				_RequestPlayerDeleteEvent(obj.IsExists() ? obj->GetDxScriptObjectID() : DxScript::ID_INVALID);
-			}
-		}
+		if (!bSpellResist_ && bPenetrateShot_) --life_;
 		break;
 	}
 	}
+
+	if (life_ == 0)
+		_RequestPlayerDeleteEvent(obj.IsExists() ? obj->GetDxScriptObjectID() : DxScript::ID_INVALID);
 }
 StgShotData* StgShotObject::_GetShotData(int id) {
 	StgShotData* res = nullptr;

--- a/source/TouhouDanmakufu/Common/StgShot.cpp
+++ b/source/TouhouDanmakufu/Common/StgShot.cpp
@@ -788,6 +788,9 @@ StgShotObject::StgShotObject(StgStageController* stageController) : StgMoveObjec
 	frameGrazeInvalid_ = 0;
 	frameGrazeInvalidStart_ = -1;
 
+	bPenetrateShot_ = true;
+	frameEnemyHitInvalid_ = 0;
+
 	frameFadeDelete_ = -1;
 	frameAutoDelete_ = INT_MAX;
 
@@ -905,6 +908,18 @@ void StgShotObject::_CommonWorkTask() {
 		_DeleteInFadeDelete();
 	}
 	--frameGrazeInvalid_;
+
+	if (listHitEnemy_.size() > 0) {
+		auto& itr = listHitEnemy_.begin();
+		while (itr != listHitEnemy_.end()) {
+			--itr->second;
+			if (itr->second <= 0)
+				itr = listHitEnemy_.erase(itr);
+			else
+				++itr;
+		}
+	}
+
 }
 void StgShotObject::_SendDeleteEvent(int bit) {
 	if (typeOwner_ != OWNER_ENEMY) return;
@@ -975,7 +990,7 @@ void StgShotObject::Intersect(StgIntersectionTarget* ownTarget, StgIntersectionT
 	case StgIntersectionTarget::TYPE_ENEMY_SHOT:
 	{
 		//Don't reduce penetration with lasers
-		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr) {
+		if (!bSpellResist_ && dynamic_cast<StgLaserObject*>(this) == nullptr && (otherType == StgIntersectionTarget::TYPE_ENEMY || bPenetrateShot_)) {
 			--life_;
 			if (life_ == 0) {
 				_RequestPlayerDeleteEvent(obj.IsExists() ? obj->GetDxScriptObjectID() : DxScript::ID_INVALID);

--- a/source/TouhouDanmakufu/Common/StgShot.hpp
+++ b/source/TouhouDanmakufu/Common/StgShot.hpp
@@ -299,6 +299,11 @@ protected:
 	int frameGrazeInvalid_;
 	int frameGrazeInvalidStart_;
 	int frameFadeDelete_;
+
+	bool bPenetrateShot_; // Translation: Does The Shot Lose Penetration Points Upon Colliding With Another Shot And Not An Enemy
+
+	int frameEnemyHitInvalid_;
+	std::list<std::pair<ref_unsync_weak_ptr<StgEnemyObject>, int>> listHitEnemy_;
 	
 	bool bRequestedPlayerDeleteEvent_;
 	double damage_;
@@ -377,6 +382,14 @@ public:
 	int GetGrazeInvalidFrame() { return frameGrazeInvalidStart_; }
 	void SetGrazeFrame(int frame) { frameGrazeInvalid_ = frame; }
 	bool IsValidGraze() { return frameGrazeInvalid_ <= 0; }
+
+	void SetPenetrateShotEnable(bool enable) { bPenetrateShot_ = enable; }
+	bool GetPenetrateShotEnable() { return bPenetrateShot_; }
+
+	void SetEnemyIntersectionInvalidFrame(int frame) { frameEnemyHitInvalid_ = frame; }
+	int GetEnemyIntersectionInvalidFrame() { return frameEnemyHitInvalid_;  }
+
+	std::list<std::pair<ref_unsync_weak_ptr<StgEnemyObject>, int>>& GetEnemyIntersectionInvalidFramePairList() { return listHitEnemy_;  }
 
 	int GetDelay() { return delay_.time; }
 	void SetDelay(int delay) { delay_.time = delay; }

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -459,6 +459,8 @@ static const std::vector<function> stgStageFunction = {
 	{ "ObjShot_SetGrazeInvalidFrame", StgStageScript::Func_ObjShot_SetGrazeInvalidFrame, 2 },
 	{ "ObjShot_SetGrazeFrame", StgStageScript::Func_ObjShot_SetGrazeFrame, 2 },
 	{ "ObjShot_IsValidGraze", StgStageScript::Func_ObjShot_IsValidGraze, 1 },
+	{ "ObjShot_SetPenetrateShotEnable", StgStageScript::Func_ObjShot_SetPenetrateShotEnable, 2 },
+	{ "ObjShot_SetEnemyIntersectionInvalidFrame", StgStageScript::Func_ObjShot_SetEnemyIntersectionInvalidFrame, 2 },
 	{ "ObjShot_SetFixedAngle", StgStageScript::Func_ObjShot_SetFixedAngle, 2 },
 	{ "ObjShot_SetSpinAngularVelocity", StgStageScript::Func_ObjShot_SetSpinAngularVelocity, 2 },
 	{ "ObjShot_SetDelayAngularVelocity", StgStageScript::Func_ObjShot_SetDelayAngularVelocity, 2 },
@@ -3911,6 +3913,24 @@ gstd::value StgStageScript::Func_ObjShot_IsValidGraze(gstd::script_machine* mach
 		res = obj->IsValidGraze();
 
 	return script->CreateBooleanValue(res);
+}
+gstd::value StgStageScript::Func_ObjShot_SetPenetrateShotEnable(gstd::script_machine* machine, int argc, const gstd::value* argv) {
+	StgStageScript* script = (StgStageScript*)machine->data;
+	int id = argv[0].as_int();
+	if (StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id))) {
+		bool enable = argv[1].as_boolean();
+		obj->SetPenetrateShotEnable(enable);
+	}
+	return value();
+}
+gstd::value StgStageScript::Func_ObjShot_SetEnemyIntersectionInvalidFrame(gstd::script_machine* machine, int argc, const gstd::value* argv) {
+	StgStageScript* script = (StgStageScript*)machine->data;
+	int id = argv[0].as_int();
+	if (StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id))) {
+		int frame = argv[1].as_int();
+		obj->SetEnemyIntersectionInvalidFrame(frame);
+	}
+	return value();
 }
 gstd::value StgStageScript::Func_ObjShot_SetFixedAngle(gstd::script_machine* machine, int argc, const gstd::value* argv) {
 	StgStageScript* script = (StgStageScript*)machine->data;

--- a/source/TouhouDanmakufu/Common/StgStageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.hpp
@@ -403,6 +403,8 @@ public:
 	DNH_FUNCAPI_DECL_(Func_ObjShot_SetGrazeInvalidFrame);
 	DNH_FUNCAPI_DECL_(Func_ObjShot_SetGrazeFrame);
 	DNH_FUNCAPI_DECL_(Func_ObjShot_IsValidGraze);
+	DNH_FUNCAPI_DECL_(Func_ObjShot_SetPenetrateShotEnable);
+	DNH_FUNCAPI_DECL_(Func_ObjShot_SetEnemyIntersectionInvalidFrame);
 	DNH_FUNCAPI_DECL_(Func_ObjShot_SetFixedAngle);
 	DNH_FUNCAPI_DECL_(Func_ObjShot_SetSpinAngularVelocity);
 	DNH_FUNCAPI_DECL_(Func_ObjShot_SetDelayAngularVelocity);


### PR DESCRIPTION
Additions:
- ObjShot_SetPenetrateShot(int, bool): Sets whether a shot object will lose penetration (life) points upon colliding with other shots. Defaults to true. Requested by Conarnar.
- ObjShot_SetEnemyIntersectionInvalidFrame(int, int): Sets the amount of frames after which a shot object is allowed to damage an enemy (and lose 1 penetration in the process) after previously dealing damage to it. Has the convenient side-effect of making it so that player shots with multiple hitboxes only hit once per frame when the invalid frame is set to 1. Defaults to 0 (disabled).

Changes:
- Removed laser objects' exemption from losing penetration (life) points Literally Ever. (They default to having 9999999 life and spell resistance anyway?)
- Templated the main five interpolation functions.