### PR TITLE
Interpolate_X_Array

### DIFF
--- a/source/GcLib/gstd/Script/ScriptFunction.cpp
+++ b/source/GcLib/gstd/Script/ScriptFunction.cpp
@@ -59,14 +59,15 @@ namespace gstd {
 	static inline const bool _is_force_convert_real(type_data* type) {
 		return type->get_kind() & (type_data::tk_real | type_data::tk_array);
 	}
-	static const void _raise_error_unsupported(script_machine* machine, type_data* type, const std::string& op_name) {
+
+	//-------------------------------------------------------------------------------------------
+
+	const void BaseFunction::_raise_error_unsupported(script_machine* machine, type_data* type, const std::string& op_name) {
 		std::string error = StringUtility::Format("This value type does not support the %s operation: %s\r\n",
 			op_name.c_str(), type_data::string_representation(type).c_str());
 		if (machine) machine->raise_error(error);
 		else throw error;
 	}
-
-	//-------------------------------------------------------------------------------------------
 
 	type_data::type_kind BaseFunction::_type_test_promotion(type_data* type_l, type_data* type_r) {
 		uint8_t kind_l = type_l->get_kind();

--- a/source/GcLib/gstd/Script/ScriptFunction.hpp
+++ b/source/GcLib/gstd/Script/ScriptFunction.hpp
@@ -40,6 +40,8 @@ namespace gstd {
 
 	class BaseFunction {
 	public:
+		static const void BaseFunction::_raise_error_unsupported(script_machine* machine, type_data* type, const std::string& op_name);
+
 		static type_data::type_kind _type_test_promotion(type_data* type_l, type_data* type_r);
 
 		static bool __type_assign_check(type_data* type_src, type_data* type_dst);

--- a/source/GcLib/gstd/ScriptClient.cpp
+++ b/source/GcLib/gstd/ScriptClient.cpp
@@ -136,7 +136,7 @@ static const std::vector<function> commonFunction = {
 	{ "Interpolate_Hermite", ScriptClientBase::Func_Interpolate_Hermite, 9 },
 	{ "Interpolate_X", ScriptClientBase::Func_Interpolate_X, 4 },
 	{ "Interpolate_X_PackedInt", ScriptClientBase::Func_Interpolate_X_Packed, 4 },
-    { "Interpolate_Array", ScriptClientBase::Func_Interpolate_Array, 3 },
+    { "Interpolate_X_Array", ScriptClientBase::Func_Interpolate_X_Array, 3 },
 
 	//Rotation
 	{ "Rotate2D", ScriptClientBase::Func_Rotate2D, 3 },
@@ -1005,7 +1005,7 @@ value ScriptClientBase::Func_Interpolate_X_Packed(script_machine* machine, int a
 	return CreateIntValue(res);
 }
 // :souperdying:
-value ScriptClientBase::Func_Interpolate_Array(script_machine* machine, int argc, const value* argv) { 
+value ScriptClientBase::Func_Interpolate_X_Array(script_machine* machine, int argc, const value* argv) { 
 	double x = argv[1].as_real();
 
 	size_t len = argv[0].length_as_array();

--- a/source/GcLib/gstd/ScriptClient.cpp
+++ b/source/GcLib/gstd/ScriptClient.cpp
@@ -1005,30 +1005,31 @@ value ScriptClientBase::Func_Interpolate_X_Packed(script_machine* machine, int a
 	return CreateIntValue(res);
 }
 // :souperdying:
-value ScriptClientBase::Func_Interpolate_X_Array(script_machine* machine, int argc, const value* argv) { 
+value ScriptClientBase::Func_Interpolate_X_Array(script_machine* machine, int argc, const value* argv) {
+	BaseFunction::_null_check(machine, argv, argc);
+
+	const value* val = &argv[0];
+	type_data* valType = val->get_type();
+
+	if (valType->get_kind() != type_data::tk_array || val->length_as_array() == 0) {
+		BaseFunction::_raise_error_unsupported(machine, argv->get_type(), "Interpolate_X_Array");
+		return value();
+	}
+
+	std::vector<value> arr = *(val->as_array_ptr());
 	double x = argv[1].as_real();
 
-	size_t len = argv[0].length_as_array();
-	int from = (int)floor(x);
+	size_t len = arr.size();
 
-	while (from < 0) {
-		x += len;
-		from += len;
-	}
-	while (from >= len) {
-		x -= len;
-		from -= len;
-	}
-	
-
-	int to = from + 1;
-	if (to >= len) to -= len;
-	double x2 = x - from;
+	x = fmod(fmod(x, len) + len, len);
+	int from = floor(x);
+	int to = (from + 1) % len;
+	x -= from;
 
     Math::Lerp::Type type = (Math::Lerp::Type)argv[2].as_int();
 	auto lerpFunc =  Math::Lerp::GetFunc<double, double>(type);
 
-	return ScriptClientBase::CreateRealValue(lerpFunc(argv[0].index_as_array(from).as_real(), argv[0].index_as_array(to).as_real(), x2));
+	return _ScriptValueLerp(machine, &arr[from], &arr[to], x, lerpFunc);
 }
 
 value ScriptClientBase::Func_Rotate2D(script_machine* machine, int argc, const value* argv) {

--- a/source/GcLib/gstd/ScriptClient.cpp
+++ b/source/GcLib/gstd/ScriptClient.cpp
@@ -136,6 +136,7 @@ static const std::vector<function> commonFunction = {
 	{ "Interpolate_Hermite", ScriptClientBase::Func_Interpolate_Hermite, 9 },
 	{ "Interpolate_X", ScriptClientBase::Func_Interpolate_X, 4 },
 	{ "Interpolate_X_PackedInt", ScriptClientBase::Func_Interpolate_X_Packed, 4 },
+    { "Interpolate_Array", ScriptClientBase::Func_Interpolate_Array, 3 },
 
 	//Rotation
 	{ "Rotate2D", ScriptClientBase::Func_Rotate2D, 3 },
@@ -1002,6 +1003,32 @@ value ScriptClientBase::Func_Interpolate_X_Packed(script_machine* machine, int a
 		res |= tmp << i;
 	}
 	return CreateIntValue(res);
+}
+// :souperdying:
+value ScriptClientBase::Func_Interpolate_Array(script_machine* machine, int argc, const value* argv) { 
+	double x = argv[1].as_real();
+
+	size_t len = argv[0].length_as_array();
+	int from = (int)floor(x);
+
+	while (from < 0) {
+		x += len;
+		from += len;
+	}
+	while (from >= len) {
+		x -= len;
+		from -= len;
+	}
+	
+
+	int to = from + 1;
+	if (to >= len) to -= len;
+	double x2 = x - from;
+
+    Math::Lerp::Type type = (Math::Lerp::Type)argv[2].as_int();
+	auto lerpFunc =  Math::Lerp::GetFunc<double, double>(type);
+
+	return ScriptClientBase::CreateRealValue(lerpFunc(argv[0].index_as_array(from).as_real(), argv[0].index_as_array(to).as_real(), x2));
 }
 
 value ScriptClientBase::Func_Rotate2D(script_machine* machine, int argc, const value* argv) {

--- a/source/GcLib/gstd/ScriptClient.hpp
+++ b/source/GcLib/gstd/ScriptClient.hpp
@@ -262,7 +262,7 @@ namespace gstd {
 
 		DNH_FUNCAPI_DECL_(Func_Interpolate_X);
 		DNH_FUNCAPI_DECL_(Func_Interpolate_X_Packed);
-		DNH_FUNCAPI_DECL_(Func_Interpolate_Array);
+		DNH_FUNCAPI_DECL_(Func_Interpolate_X_Array);
 
 		//Math functions; rotation
 		DNH_FUNCAPI_DECL_(Func_Rotate2D);

--- a/source/GcLib/gstd/ScriptClient.hpp
+++ b/source/GcLib/gstd/ScriptClient.hpp
@@ -262,6 +262,7 @@ namespace gstd {
 
 		DNH_FUNCAPI_DECL_(Func_Interpolate_X);
 		DNH_FUNCAPI_DECL_(Func_Interpolate_X_Packed);
+		DNH_FUNCAPI_DECL_(Func_Interpolate_Array);
 
 		//Math functions; rotation
 		DNH_FUNCAPI_DECL_(Func_Rotate2D);


### PR DESCRIPTION
Arguments:
- (T[]) array
- (real) x
- (int) type

Return Value:
- (T) result

Interpolates between the values of two adjacent array elements, using x as the interpolation value.
For example, an x value of 2.5 will interpolate between the elements indexed 2 and 3.

The indices wrap around automatically, so an x value of -0.5 will interpolate between the last and first elements.