### PR TITLE
ObjEnemy_SetDamageRateToShotID, adjusted damage rate ranges

### DIFF
--- a/source/TouhouDanmakufu/Common/StgEnemy.cpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.cpp
@@ -140,8 +140,8 @@ StgEnemyObject::StgEnemyObject(StgStageController* stageController) : StgMoveObj
 
 	life_ = 0;
 	lifePrev_ = 0;
-	rateDamageShot_ = 100;
-	rateDamageSpell_ = 100;
+	rateDamageShot_ = 1;
+	rateDamageSpell_ = 1;
 
 	maximumDamage_ = 256 * 256 * 256;
 	damageAccumFrame_ = 0;
@@ -211,7 +211,7 @@ void StgEnemyObject::Intersect(StgIntersectionTarget* ownTarget, StgIntersection
 				if (ref_unsync_weak_ptr<StgEnemyObject> self = ownTarget->GetObject()) {
 					//Register intersection only if the enemy is off hit cooldown
 					if (!shot->CheckEnemyHitCooldownExists(self)) {
-						damage = shot->GetDamage() * (shot->IsSpellFactor() ? rateDamageSpell_ : rateDamageShot_) / 100.0;
+						damage = shot->GetDamage() * (shot->IsSpellFactor() ? rateDamageSpell_ : rateDamageShot_) * GetShotDamageRateByID(shot->GetShotDataID());
 						++intersectedPlayerShotCount_;
 
 						uint32_t frame = shot->GetEnemyIntersectionInvalidFrame();
@@ -223,7 +223,7 @@ void StgEnemyObject::Intersect(StgIntersectionTarget* ownTarget, StgIntersection
 		}
 		else if (otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SPELL) {
 			if (StgPlayerSpellObject* spell = dynamic_cast<StgPlayerSpellObject*>(ptrObj.get()))
-				damage = spell->GetDamage() * rateDamageSpell_ / 100;
+				damage = spell->GetDamage() * rateDamageSpell_;
 		}
 	}
 	AddLife2(-damage);

--- a/source/TouhouDanmakufu/Common/StgEnemy.hpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.hpp
@@ -76,6 +76,8 @@ protected:
 	std::vector<ref_unsync_weak_ptr<StgIntersectionTarget>> ptrIntersectionToShot_;
 	std::vector<ref_unsync_weak_ptr<StgIntersectionTarget>> ptrIntersectionToPlayer_;
 
+	std::unordered_map<int, double> mapShotDamageRate_;
+
 	void _DeleteInAutoClip();
 	void _DeleteInAutoDeleteFrame();
 	virtual void _Move();
@@ -105,8 +107,12 @@ public:
 	void AddLife2(double inc);
 
 	void SetDamageRate(double rateShot, double rateSpell) { rateDamageShot_ = rateShot; rateDamageSpell_ = rateSpell; }
+	void SetDamageRateByID(int id, double rate) { mapShotDamageRate_[id] = rate; }
 	double GetShotDamageRate() { return rateDamageShot_; }
 	double GetSpellDamageRate() { return rateDamageSpell_; }
+	double GetShotDamageRateByID(int id) {
+		return (mapShotDamageRate_.count(id) > 0) ? mapShotDamageRate_[id] : 1;
+	}
 
 	void SetMaximumDamage(double dmg) { maximumDamage_ = dmg; }
 	double GetMaximumDamage() { return maximumDamage_; }

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -415,6 +415,7 @@ static const std::vector<function> stgStageFunction = {
 	{ "ObjEnemy_AddLife", StgStageScript::Func_ObjEnemy_AddLife<false>, 2 },
 	{ "ObjEnemy_AddLifeEx", StgStageScript::Func_ObjEnemy_AddLife<true>, 2 },
 	{ "ObjEnemy_SetDamageRate", StgStageScript::Func_ObjEnemy_SetDamageRate, 3 },
+	{ "ObjEnemy_SetDamageRateToShotID", StgStageScript::Func_ObjEnemy_SetDamageRateToShotID, 3 },
 	{ "ObjEnemy_SetMaximumDamage", StgStageScript::Func_ObjEnemy_SetMaximumDamage, 2 },
 	{ "ObjEnemy_AddIntersectionCircleA", StgStageScript::Func_ObjEnemy_AddIntersectionCircleA, 4 },
 	{ "ObjEnemy_SetIntersectionCircleToShot", StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot, 4 },
@@ -3683,6 +3684,17 @@ gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* ma
 		double rateShot = argv[1].as_float();
 		double rateSpell = argv[2].as_float();
 		obj->SetDamageRate(rateShot, rateSpell);
+	}
+	return value();
+}
+gstd::value StgStageScript::Func_ObjEnemy_SetDamageRateToShotID(gstd::script_machine* machine, int argc, const gstd::value* argv) {
+	DxScript* script = (DxScript*)machine->data;
+	int id = argv[0].as_int();
+	StgEnemyObject* obj = script->GetObjectPointerAs<StgEnemyObject>(id);
+	if (obj) {
+		int gr = argv[1].as_int();
+		double rate = argv[2].as_float();
+		obj->SetDamageRateByID(gr, rate);
 	}
 	return value();
 }

--- a/source/TouhouDanmakufu/Common/StgStageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.hpp
@@ -361,6 +361,7 @@ public:
 	template<bool CHECK_MAX_DMG>
 	static gstd::value Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, const gstd::value* argv);
 	static gstd::value Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	DNH_FUNCAPI_DECL_(Func_ObjEnemy_SetDamageRateToShotID);
 	DNH_FUNCAPI_DECL_(Func_ObjEnemy_SetMaximumDamage);
 	static gstd::value Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, const gstd::value* argv);
 	static gstd::value Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, const gstd::value* argv);


### PR DESCRIPTION
Additions:
- ObjEnemy_SetDamageRateToShotID (int, int, float) -> void:
Set an enemy's damage factor to a specific shot ID. This is multiplied by the enemy's normal damage rate.

Changes:
- ObjEnemy_SetDamageRate (int, float, float) -> void:
Ranges are now between (0, 1) instead of (0, 100), for consistency with the above (and other functions).