### PR TITLE
ObjShot_SetFrameDeleteType, QOL for straight laser delays

### DIFF
--- a/source/TouhouDanmakufu/Common/StgShot.hpp
+++ b/source/TouhouDanmakufu/Common/StgShot.hpp
@@ -330,6 +330,7 @@ public:
 	bool bSpellFactor_;
 	bool bSpellResist_;
 	int frameAutoDelete_;
+	int typeAutoDelete_;
 	
 	IntersectionListType listIntersectionTarget_;
 	bool bUserIntersectionMode_;
@@ -437,6 +438,7 @@ public:
 	bool IsAutoDelete() { return bAutoDelete_; }
 	void SetAutoDelete(bool b) { bAutoDelete_ = b; }
 	void SetAutoDeleteFrame(int frame) { frameAutoDelete_ = frame; }
+	void SetAutoDeleteType(int type) { typeAutoDelete_ = type; }
 	bool IsEraseShot() { return bEraseShot_; }
 	void SetEraseShot(bool bErase) { bEraseShot_ = bErase; }
 	bool IsSpellFactor() { return bSpellFactor_; }
@@ -583,7 +585,6 @@ protected:
 	bool bLaserExpand_;
 
 	virtual void _DeleteInAutoClip();
-	virtual void _DeleteInAutoDeleteFrame();
 	virtual void _SendDeleteEvent(int type);
 public:
 	StgStraightLaserObject(StgStageController* stageController);

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -442,6 +442,7 @@ static const std::vector<function> stgStageFunction = {
 	{ "ObjShot_SetAutoDelete", StgStageScript::Func_ObjShot_SetAutoDelete, 2 },
 	{ "ObjShot_FadeDelete", StgStageScript::Func_ObjShot_FadeDelete, 1 },
 	{ "ObjShot_SetDeleteFrame", StgStageScript::Func_ObjShot_SetDeleteFrame, 2 },
+	{ "ObjShot_SetFrameDeleteType", StgStageScript::Func_ObjShot_SetFrameDeleteType, 2 },
 	{ "ObjShot_SetDelay", StgStageScript::Func_ObjShot_SetDelay, 2 },
 	{ "ObjShot_SetSpellResist", StgStageScript::Func_ObjShot_SetSpellResist, 2 },
 	{ "ObjShot_SetGraphic", StgStageScript::Func_ObjShot_SetGraphic, 2 },
@@ -4172,6 +4173,27 @@ gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* ma
 	if (obj) {
 		int frame = argv[1].as_int();
 		obj->SetAutoDeleteFrame(frame);
+	}
+	return value();
+}
+gstd::value StgStageScript::Func_ObjShot_SetFrameDeleteType(gstd::script_machine* machine, int argc, const gstd::value* argv) {
+	StgStageScript* script = (StgStageScript*)machine->data;
+	int id = argv[0].as_int();
+	StgShotObject* obj = script->GetObjectPointerAs<StgShotObject>(id);
+	if (obj) {
+		int type = argv[1].as_int();
+		switch (type) {
+		case TYPE_IMMEDIATE:
+			type = StgShotManager::TO_TYPE_IMMEDIATE;
+			break;
+		case TYPE_FADE:
+			type = StgShotManager::TO_TYPE_FADE;
+			break;
+		case TYPE_ITEM:
+			type = StgShotManager::TO_TYPE_ITEM;
+			break;
+		}
+		obj->SetAutoDeleteType(type);
 	}
 	return value();
 }

--- a/source/TouhouDanmakufu/Common/StgStageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.hpp
@@ -386,6 +386,7 @@ public:
 	DNH_FUNCAPI_DECL_(Func_ObjShot_SetOwnerType);
 	static gstd::value Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, const gstd::value* argv);
 	static gstd::value Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	DNH_FUNCAPI_DECL_(Func_ObjShot_SetFrameDeleteType);
 	static gstd::value Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, const gstd::value* argv);
 	static gstd::value Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv);
 	static gstd::value Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv);


### PR DESCRIPTION
Additions:
- ObjShot_SetFrameDeleteType (int, int) -> void:
Set the delete event that will be triggered when a shot's deletion frame is reached (set with ObjShot_SetDeleteFrame).
Possible values are TYPE_IMMEDIATE, TYPE_FADE, and TYPE_ITEM. Default for all shots and lasers is now TYPE_FADE.

Changes:
- Straight lasers that spawn with 0 delay frames are automatically set to their full widths.
- Straight lasers now visually "retract" when a delay period is added after they fully expand, allowing for them to seamlessly transition between active and inactive states.