### PR TITLE
Fix the odd off-center rotation issue in Danmakufu

### DIFF
--- a/source/GcLib/directx/DirectGraphics.hpp
+++ b/source/GcLib/directx/DirectGraphics.hpp
@@ -55,6 +55,7 @@ namespace directx {
 		static DirectGraphics* thisBase_;
 	public:
 		static float g_dxCoordsMul_;
+		static constexpr float g_dxBias_ = 0.5;
 	protected:
 		D3DPRESENT_PARAMETERS d3dppFull_;
 		D3DPRESENT_PARAMETERS d3dppWin_;

--- a/source/GcLib/directx/DxObject.cpp
+++ b/source/GcLib/directx/DxObject.cpp
@@ -246,9 +246,8 @@ D3DXVECTOR3 DxScriptPrimitiveObject2D::GetVertexPosition(size_t index) {
 	RenderObjectTLX* obj = GetRenderObject();
 	VERTEX_TLX* vert = obj->GetVertex(index);
 
-	constexpr float bias = 0.5f;
-	res.x = vert->position.x + bias;
-	res.y = vert->position.y + bias;
+	res.x = vert->position.x;
+	res.y = vert->position.y;
 	res.z = 0;
 
 	return res;

--- a/source/GcLib/directx/DxText.cpp
+++ b/source/GcLib/directx/DxText.cpp
@@ -735,6 +735,9 @@ void DxTextRenderObject::Render(const D3DXVECTOR2& angX, const D3DXVECTOR2& angY
 
 		D3DXMATRIX matWorld = RenderObject::CreateWorldMatrixText2D(center, scale_, angX, angY, angZ,
 			position, bias, bCamera ? &DirectGraphics::GetBase()->GetCamera2D()->GetMatrix() : nullptr);
+		
+		matWorld._41 -= DirectGraphics::g_dxBias_;
+		matWorld._42 -= DirectGraphics::g_dxBias_;
 
 		sprite->SetPermitCamera(false);
 		sprite->SetShader(shader_);

--- a/source/GcLib/directx/MetasequoiaMesh.cpp
+++ b/source/GcLib/directx/MetasequoiaMesh.cpp
@@ -523,6 +523,9 @@ void MetasequoiaMesh::Render(const D3DXVECTOR2& angX, const D3DXVECTOR2& angY, c
 		D3DXMATRIX mat = RenderObject::CreateWorldMatrix(position_, scale_,
 			angX, angY, angZ, &camera->GetIdentity(), bCoordinate2D_);
 		device->SetTransform(D3DTS_WORLD, &mat);
+		
+		mat._41 -= DirectGraphics::g_dxBias_;
+		mat._42 -= DirectGraphics::g_dxBias_;
 
 		{
 			size_t i = 0;

--- a/source/TouhouDanmakufu/Common/StgShot.cpp
+++ b/source/TouhouDanmakufu/Common/StgShot.cpp
@@ -1014,13 +1014,11 @@ StgShotData* StgShotObject::_GetShotData(int id) {
 }
 
 void StgShotObject::_SetVertexPosition(VERTEX_TLX* vertex, float x, float y, float z, float w) {
-	constexpr float bias = 0.0f;
-
 	x *= DirectGraphics::g_dxCoordsMul_;
 	y *= DirectGraphics::g_dxCoordsMul_;
 
-	vertex->position.x = x + bias;
-	vertex->position.y = y + bias;
+	vertex->position.x = x;
+	vertex->position.y = y;
 	vertex->position.z = z;
 	vertex->position.w = w;
 }
@@ -1609,6 +1607,8 @@ void StgNormalShotObject::Render(BlendMode targetBlend) {
 		sposx = roundf(sposx);
 		sposy = roundf(sposy);
 	}
+	sposx -= DirectGraphics::g_dxBias_;
+	sposy -= DirectGraphics::g_dxBias_;
 
 	float scaleX = 1.0f;
 	float scaleY = 1.0f;

--- a/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.cpp
@@ -276,14 +276,13 @@ void EApplication::_RenderDisplay() {
 
 			std::array<VERTEX_TLX, 4> verts;
 			auto _Render = [](IDirect3DDevice9* device, VERTEX_TLX* verts, const D3DXMATRIX* mat) {
-				constexpr float bias = -0.5f;
 				for (size_t iVert = 0; iVert < 4; ++iVert) {
 					VERTEX_TLX* vertex = (VERTEX_TLX*)verts + iVert;
 					vertex->diffuse_color = 0xffffffff;
 
 					D3DXVECTOR4* vPos = &vertex->position;
-					vPos->x += bias;
-					vPos->y += bias;
+					vPos->x -= DirectGraphics::g_dxBias_;
+					vPos->y -= DirectGraphics::g_dxBias_;
 
 					D3DXVec3TransformCoord((D3DXVECTOR3*)vPos, (D3DXVECTOR3*)vPos, mat);
 				}
@@ -343,11 +342,10 @@ void EApplication::_RenderDisplay() {
 				verts[3] = VERTEX_TLX(D3DXVECTOR4(scW, scH, 0, 1), 0xffffffff,
 					D3DXVECTOR2(scW / texW, scH / texH));
 				{
-					constexpr float bias = -0.5f;
 					for (size_t iVert = 0; iVert < 4; ++iVert) {
 						D3DXVECTOR4* vPos = &verts[iVert].position;
-						vPos->x += bias;
-						vPos->y += bias;
+						vPos->x -= DirectGraphics::g_dxBias_;
+						vPos->y -= DirectGraphics::g_dxBias_;
 					}
 				}
 


### PR DESCRIPTION
Because Danmakufu uses Direct3D 9, it uses texels instead of pixels in it's coordinate system. MKM tried to fix this by applying a 0.5 offset to the vertexes of graphics but this actually causes the graphics to be off-center. This pull-request changes it so the offsets are applied to the actual positions of the graphics and not the vertexes.

This may not be the best way of going about fixing it but I do hope at the very least some insight can be derived from the comparisons in this pull.